### PR TITLE
fix: fix to check the negative cache size

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -15,6 +15,7 @@ const (
 
 // Metrics contains metrics exposed by this package.
 type Metrics struct {
+	NodeCacheSize   metrics.Gauge
 	NodeCacheHits   metrics.Counter
 	NodeCacheMisses metrics.Counter
 }
@@ -28,6 +29,12 @@ func PrometheusMetrics(namespace string, storeName string, labelsAndValues ...st
 		labels = append(labels, labelsAndValues[i])
 	}
 	return &Metrics{
+		NodeCacheSize: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      storeName + "_node_cache_size",
+			Help:      "The maximum number of entries in the iavl node db cache",
+		}, labels).With(labelsAndValues...),
 		NodeCacheHits: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -46,6 +53,7 @@ func PrometheusMetrics(namespace string, storeName string, labelsAndValues ...st
 // NopMetrics returns no-op Metrics.
 func NopMetrics() *Metrics {
 	return &Metrics{
+		NodeCacheSize:   discard.NewGauge(),
 		NodeCacheHits:   discard.NewCounter(),
 		NodeCacheMisses: discard.NewCounter(),
 	}

--- a/nodedb.go
+++ b/nodedb.go
@@ -59,6 +59,7 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 	if cacheSize < 0 {
 		cacheSize = 0
 	}
+	opts.Metrics.NodeCacheSize.Set(float64(cacheSize))
 	return &nodeDB{
 		db:             db,
 		batch:          db.NewBatch(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix to check the negative cache size
- add a metric for node db cache size

## Motivation and context
node db cache size is `int` but there is no exception handling for negative value.
I don't replace `int` with `uint` because I'm concerned about the side effect of the code being changed.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
