### PR TITLE
nodedb - parallel processing instead of a single batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,101 @@
+package iavl
+
+import (
+	"sync"
+
+	tmdb "github.com/line/tm-db/v2"
+)
+
+var DefaultBatchSize int = 5000
+
+type Batch struct {
+	db        tmdb.DB
+	batchSize int
+	count     int
+	curr      tmdb.Batch
+	batches   []tmdb.Batch
+}
+
+func NewBatch(db tmdb.DB, batchSize int) tmdb.Batch {
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+	return &Batch{
+		db:        db,
+		batchSize: batchSize,
+		count:     0,
+		curr:      db.NewBatch(),
+	}
+}
+
+func (b *Batch) prep() {
+	n := b.count % b.batchSize
+	if b.count != 0 && n == 0 {
+		// need a new batch
+		if b.curr != nil {
+			b.batches = append(b.batches, b.curr)
+		}
+		b.curr = b.db.NewBatch()
+	}
+}
+
+func (b *Batch) Set(key, value []byte) error {
+	b.prep()
+	err := b.curr.Set(key, value)
+	if err == nil {
+		b.count += 1
+	}
+	return err
+}
+
+func (b *Batch) Delete(key []byte) error {
+	b.prep()
+	err := b.curr.Delete(key)
+	if err == nil {
+		b.count += 1
+	}
+	return err
+}
+
+func (b *Batch) Write() error {
+	if b.count <= 0 {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	var err error
+
+	write := func(bb tmdb.Batch) {
+		errr := bb.Write()
+		if errr != nil {
+			err = errr
+		}
+		wg.Done()
+	}
+
+	for _, b := range b.batches {
+		wg.Add(1)
+		go write(b)
+	}
+	wg.Add(1)
+	go write(b.curr)
+
+	wg.Wait()
+
+	return err
+}
+
+func (b *Batch) WriteSync() error {
+	return b.Write()
+}
+
+func (b *Batch) Close() error {
+	for _, bb := range b.batches {
+		bb.Close()
+	}
+	if b.curr != nil {
+		b.curr.Close()
+	}
+	b.batches = nil
+	return nil
+}

--- a/nodedb.go
+++ b/nodedb.go
@@ -60,7 +60,7 @@ func newNodeDBWithCache(db tmdb.DB, cache *fastcache.Cache, opts *Options) *node
 	}
 	return &nodeDB{
 		db:             db,
-		batch:          db.NewBatch(),
+		batch:          NewBatch(db, 0),
 		opts:           *opts,
 		latestVersion:  0, // initially invalid
 		nodeCache:      cache,
@@ -543,7 +543,7 @@ func (ndb *nodeDB) Commit() error {
 	}
 
 	ndb.batch.Close()
-	ndb.batch = ndb.db.NewBatch()
+	ndb.batch = NewBatch(ndb.db, 0)
 
 	return nil
 }


### PR DESCRIPTION
feat: parallel batch write instead of one big batch in nodedb commit. Measurable performance gain, but not as much as expected.

One thing to note is that if a node appears more than once in the batch, the behavior is not deterministic. In iavl case, however, commit happens only by mutable_tree.SaveVersion, in which a node can be saved only once.

Another possible way to improve performance in the future is auto flush when write / set count reaches threshold.