### PR TITLE
feat: thread safe versions load / save

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -2,6 +2,7 @@ package iavl
 
 import (
 	"sync"
+	"sync/atomic"
 
 	tmdb "github.com/line/tm-db/v2"
 )
@@ -40,19 +41,22 @@ func (b *Batch) prep() {
 }
 
 func (b *Batch) Set(key, value []byte) error {
+	atomic.AddUint64(&nodeSetCount, 1)
+	atomic.AddUint64(&nodeSetBytes, uint64(len(key)+len(value)))
 	b.prep()
 	err := b.curr.Set(key, value)
 	if err == nil {
-		b.count += 1
+		b.count++
 	}
 	return err
 }
 
 func (b *Batch) Delete(key []byte) error {
+	atomic.AddUint64(&nodeDelCount, 1)
 	b.prep()
 	err := b.curr.Delete(key)
 	if err == nil {
-		b.count += 1
+		b.count++
 	}
 	return err
 }

--- a/nodestats.go
+++ b/nodestats.go
@@ -1,0 +1,14 @@
+package iavl
+
+var (
+	// updated node stats
+	nodeSetCount uint64
+	nodeSetBytes uint64
+	nodeDelCount uint64
+)
+
+// returns updated node stats
+func GetDBStats() (setCount, setBytes, delCount uint64) {
+	setCount, setBytes, delCount = nodeSetCount, nodeSetBytes, nodeDelCount
+	return
+}

--- a/proof_range.go
+++ b/proof_range.go
@@ -541,7 +541,7 @@ func (t *ImmutableTree) GetRangeWithProof(startKey []byte, endKey []byte, limit 
 // GetVersionedWithProof gets the value under the key at the specified version
 // if it exists, or returns nil.
 func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byte, *RangeProof, error) {
-	if tree.versions[version] {
+	if b, ok := tree.versions.Load(version); ok && b.(bool) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, err
@@ -556,8 +556,7 @@ func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byt
 // and limit.
 func (tree *MutableTree) GetVersionedRangeWithProof(startKey, endKey []byte, limit int, version int64) (
 	keys, values [][]byte, proof *RangeProof, err error) {
-
-	if tree.versions[version] {
+	if b, ok := tree.versions.Load(version); ok && b.(bool) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, nil, err

--- a/tree_test.go
+++ b/tree_test.go
@@ -84,7 +84,12 @@ func TestVersionedRandomTree(t *testing.T) {
 		tree.DeleteVersion(int64(i))
 	}
 
-	require.Len(tree.versions, 1, "tree must have one version left")
+	versionsLength := 0
+	tree.versions.Range(func(k, v interface{}) bool {
+		versionsLength++
+		return true
+	})
+	require.Equal(versionsLength, 1, "tree must have one version left")
 	tr, err := tree.GetImmutable(int64(versions))
 	require.NoError(err, "GetImmutable should not error for version %d", versions)
 	require.Equal(tr.root, tree.root)
@@ -407,7 +412,12 @@ func TestVersionedTree(t *testing.T) {
 	_, err = tree.Load()
 	require.NoError(err)
 
-	require.Len(tree.versions, 2, "wrong number of versions")
+	versionsLength := 0
+	tree.versions.Range(func(k, v interface{}) bool {
+		versionsLength++
+		return true
+	})
+	require.Equal(versionsLength, 2, "wrong number of versions")
 	require.EqualValues(v2, tree.Version())
 
 	// -----1-----


### PR DESCRIPTION
Thread-safe versions handling to enable concurrent iavl access. For now, it's to make pruning work in the background. Later we'll need this to enable multi-reader / single-writer access.